### PR TITLE
Toggle night when you click the night-toggle-icon

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -66,7 +66,7 @@ function Home() {
   const isBig = window.innerWidth > 450;
 
   // methods
-  const onToggleSwitch = () => {
+  const onToggleNight = () => {
     setNight(n => !n);
     setToggleCount(toggleCount + 1);
   };
@@ -105,7 +105,12 @@ function Home() {
           <S.Content innerRef={contentRef}>
             <S.WindowBox innerRef={messagesWindowRef} initialPose="hidden" pose={homePose} {...windowCenter}>
               <S.Window night={night} hovering={isHoveringMessages.value}>
-                <Messages messagesPose={messagesPose} fabPose={fabPose} night={night} />
+                <Messages
+                  messagesPose={messagesPose}
+                  fabPose={fabPose}
+                  night={night}
+                  onToggleNight={onToggleNight}
+                />
               </S.Window>
             </S.WindowBox>
 
@@ -135,7 +140,7 @@ function Home() {
 
               <A.Space />
 
-              <DayNightSwitch value={night} onChange={onToggleSwitch} />
+              <DayNightSwitch value={night} onChange={onToggleNight} />
               <ToggleCount onTweet={tweetProgress} count={toggleCount} />
             </S.TextContent>
           </S.Content>
@@ -145,7 +150,9 @@ function Home() {
             <S.Link href="mailto:contact@twizzy.app">Contact</S.Link>
             <S.Link href="privacy.html">Privacy</S.Link>
             <S.Link href="disclaimer.html">Disclaimer</S.Link>
-            <S.Link target="_blank" rel="noopener" href="https://github.com/kitze/twizzy-landing">View source</S.Link>
+            <S.Link target="_blank" rel="noopener" href="https://github.com/kitze/twizzy-landing">
+              View source
+            </S.Link>
           </S.Links>
         </S.Footer>
       </S.Home>

--- a/src/components/Messages/index.js
+++ b/src/components/Messages/index.js
@@ -16,13 +16,13 @@ import * as A from 'styles/shared-components';
 //components
 import { PoseGroup } from 'react-pose';
 
-function Messages({ messagesPose, fabPose }) {
+function Messages({ messagesPose, fabPose, onToggleNight }) {
   return (
     <S.Messages>
       <S.Bar>
         <S.Title> Messages </S.Title>
         <A.Horizontal spaceAll={10}>
-          <S.Icon icon={faMoon} />
+          <S.Icon icon={faMoon} onClick={onToggleNight} style={{ cursor: 'pointer' }} />
           <S.Icon icon={faBars} />
           <S.Icon icon={faCog} />
         </A.Horizontal>

--- a/src/icons/Icon.js
+++ b/src/icons/Icon.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-function Icon({ icon: Icon, className, style }) {
-  return <Icon className={className} style={style} />;
+function Icon({ icon: Icon, className, style, onClick }) {
+  return <Icon className={className} style={style} onClick={onClick} />;
 }
 
 export default Icon;


### PR DESCRIPTION
I'm sorry, it rubbed me the wrong way that you can toggle night with a switch on the home page but not from the icon that's built for that in the preview

![twizzy](https://user-images.githubusercontent.com/1863771/48913809-6fd8e280-ee71-11e8-8b3c-9dd40fe764f6.gif)
